### PR TITLE
Minor changes to compile against latest morphologica

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ else()
   message(ERROR "Operating system not supported: " ${CMAKE_SYSTEM})
 endif()
 
-# morphologica uses c++-17 language features
-set(CMAKE_CXX_STANDARD 17)
+# morphologica uses c++-20 language features
+set(CMAKE_CXX_STANDARD 20)
 # Add the host definition to CXXFLAGS along with other switches, depending on OS/Compiler
 if (APPLE)
   set(CMAKE_CXX_FLAGS "${OS_FLAG} -Wall -Wfatal-errors -g -O3")
@@ -79,5 +79,3 @@ if(DEBUG_VARIABLES)
     message(STATUS "${_variableName}=${${_variableName}}")
   endforeach()
 endif(DEBUG_VARIABLES)
-
-

--- a/em.cpp
+++ b/em.cpp
@@ -15,7 +15,7 @@ int main()
 {
 
     //Visual model setup
-    morph::Visual v(1024, 768, "morph::QuiverVisual", {0.8,-0.8}, {.05,.05,.05}, 2.0f, 0.01f);
+    morph::Visual v(1024, 768, "morph::QuiverVisual");
     morph::vec<float, 3> offset = { 0.0, 0.0, 0.0 };
     v.zNear = 0.001;
     v.showCoordArrows = true;


### PR DESCRIPTION
Most recent morphologica uses C++20 standards, and I got rid of the annoying Visual constructors that have too many arguments.